### PR TITLE
Correct the node upgrade order according to their roles and Implement upgrade checkpointing

### DIFF
--- a/server/src/main/java/co/hyperflex/entities/upgrade/ClusterUpgradeJob.java
+++ b/server/src/main/java/co/hyperflex/entities/upgrade/ClusterUpgradeJob.java
@@ -1,5 +1,7 @@
 package co.hyperflex.entities.upgrade;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -12,6 +14,7 @@ public class ClusterUpgradeJob {
   private String currentVersion;
   private String targetVersion;
   private boolean isActive;
+  private Map<String, Integer> nodeCheckPoints = new HashMap<>();
   private ClusterUpgradeStatus status = ClusterUpgradeStatus.PENDING;
 
 
@@ -61,5 +64,13 @@ public class ClusterUpgradeJob {
 
   public void setStatus(ClusterUpgradeStatus status) {
     this.status = status;
+  }
+
+  public Map<String, Integer> getNodeCheckPoints() {
+    return nodeCheckPoints;
+  }
+
+  public void setNodeCheckPoints(Map<String, Integer> nodeCheckPoints) {
+    this.nodeCheckPoints = nodeCheckPoints;
   }
 }

--- a/server/src/test/java/co/hyperflex/utils/NodeRoleRankerUtilsTest.java
+++ b/server/src/test/java/co/hyperflex/utils/NodeRoleRankerUtilsTest.java
@@ -9,12 +9,54 @@ class NodeRoleRankerUtilsTest {
   @Test
   void testMasterEligibleAndDataRoleRank() {
     int rank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("data", "master"), false);
-    Assertions.assertEquals(40, rank);
+    Assertions.assertEquals(52, rank);
+  }
+
+  @Test
+  void testMasterRoleRank() {
+    int rank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("master"), true);
+    Assertions.assertEquals(150, rank);
+  }
+
+  @Test
+  void testKibanaRoleRank() {
+    int rank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("kibana"), false);
+    Assertions.assertEquals(200, rank);
   }
 
   @Test
   void testMasterEligibleRoleRank() {
     int rank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("master"), false);
-    Assertions.assertEquals(50, rank);
+    Assertions.assertEquals(80, rank);
+  }
+
+  @Test
+  void testRealWorldUpgradeOrder() {
+    // Simulating a real-world cluster with different node roles
+    int kibanaRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("kibana"), false);
+    int activeMasterRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("master"), true);
+    int masterEligibleRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("master"), false);
+    int masterEligibleDataWarmRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("master", "data_warm"), false);
+    int masterEligibleDataRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("master", "data"), false);
+    int dataHotRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("data_hot"), false);
+    int dataWarmRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("data_warm"), false);
+    int dataColdRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("data_cold"), false);
+    int ingestRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("ingest"), false);
+    int mlRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("ml"), false);
+    int mlDataRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of("ml", "data"), false);
+    int coordinatingOnlyRank = NodeRoleRankerUtils.getNodeRankByRoles(List.of(), false);
+
+    // Asserting the upgrade order based on ranks (higher rank = later upgrade)
+    Assertions.assertTrue(kibanaRank > activeMasterRank);
+    Assertions.assertTrue(activeMasterRank > masterEligibleRank);
+    Assertions.assertTrue(masterEligibleRank > masterEligibleDataRank);
+    Assertions.assertTrue(masterEligibleDataRank > masterEligibleDataWarmRank);
+    Assertions.assertTrue(masterEligibleDataRank > dataHotRank);
+    Assertions.assertTrue(dataHotRank > dataWarmRank);
+    Assertions.assertTrue(dataWarmRank > dataColdRank);
+    Assertions.assertTrue(dataColdRank > mlRank);
+    Assertions.assertTrue(mlDataRank > dataColdRank);
+    Assertions.assertTrue(mlRank > ingestRank);
+    Assertions.assertTrue(ingestRank > coordinatingOnlyRank);
   }
 }


### PR DESCRIPTION
Changes:
- Added support for data tier in node ranker
- Implemented checkpoint so when we retry failed upgrade it resume from last failed task