### PR TITLE
Improve Performance with Elasticsearch Client Caching and Ssh-Based Command Execution

### DIFF
--- a/.idea/dataSources.local.xml
+++ b/.idea/dataSources.local.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="dataSourceStorageLocal" created-in="IU-251.26927.53">
+  <component name="dataSourceStorageLocal" created-in="IU-251.27812.49">
     <data-source name="postgres@localhost" uuid="3212baa2-6d72-4a17-8e17-39a6dde684b4">
       <database-info product="PostgreSQL" version="17.5 (Homebrew)" jdbc-version="4.2" driver-name="PostgreSQL JDBC Driver" driver-version="42.7.3" dbms="POSTGRES" exact-version="17.5" exact-driver-version="42.7">
         <identifier-quote-string>&quot;</identifier-quote-string>

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
-
+    implementation 'org.apache.sshd:sshd-core:2.15.0'
     //Dev dependencies
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/server/src/main/java/co/hyperflex/clients/elastic/ElasticClient.java
+++ b/server/src/main/java/co/hyperflex/clients/elastic/ElasticClient.java
@@ -34,7 +34,7 @@ import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ElasticClient {
+public class ElasticClient implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(ElasticClient.class);
   private final ElasticsearchClient elasticsearchClient;
   private final RestClient restClient;
@@ -196,5 +196,11 @@ public class ElasticClient {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public void close() throws Exception {
+    getElasticsearchClient().close();
+    restClient.close();
   }
 }

--- a/server/src/main/java/co/hyperflex/clients/elastic/ElasticsearchClientProvider.java
+++ b/server/src/main/java/co/hyperflex/clients/elastic/ElasticsearchClientProvider.java
@@ -39,7 +39,7 @@ public class ElasticsearchClientProvider {
   }
 
   @Cacheable(value = "elasticClientCache", key = "#clusterId")
-  public synchronized ElasticClient getClientByClusterId(@NotNull String clusterId) {
+  public ElasticClient getClientByClusterId(@NotNull String clusterId) {
     return clusterRepository.findById(clusterId).map(ElasticsearchClientProvider.this::buildElasticClient)
         .orElseThrow(() -> new NotFoundException("Cluster not found"));
   }

--- a/server/src/main/java/co/hyperflex/clients/elastic/ElasticsearchClientProvider.java
+++ b/server/src/main/java/co/hyperflex/clients/elastic/ElasticsearchClientProvider.java
@@ -18,6 +18,7 @@ import org.apache.http.ssl.SSLContextBuilder;
 import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 
@@ -37,12 +38,13 @@ public class ElasticsearchClientProvider {
     this.objectMapper = objectMapper;
   }
 
-  public ElasticClient getElasticsearchClientByClusterId(@NotNull String clusterId) {
-    return clusterRepository.findById(clusterId).map(this::getClient)
+  @Cacheable(value = "elasticClientCache", key = "#clusterId")
+  public synchronized ElasticClient getClientByClusterId(@NotNull String clusterId) {
+    return clusterRepository.findById(clusterId).map(ElasticsearchClientProvider.this::buildElasticClient)
         .orElseThrow(() -> new NotFoundException("Cluster not found"));
   }
 
-  public ElasticClient getClient(Cluster cluster) {
+  public ElasticClient buildElasticClient(Cluster cluster) {
     try {
       SSLContext sslContext = SSLContextBuilder.create()
           .loadTrustMaterial(null, (X509Certificate[] chain, String authType) -> true)

--- a/server/src/main/java/co/hyperflex/configs/CacheConfig.java
+++ b/server/src/main/java/co/hyperflex/configs/CacheConfig.java
@@ -20,10 +20,11 @@ public class CacheConfig {
 
   @Bean
   public CacheManager cacheManager() {
-    CaffeineCache elasticClientCache = getElasticClientCache();
-
     SimpleCacheManager manager = new SimpleCacheManager();
-    manager.setCaches(List.of(elasticClientCache));
+    manager.setCaches(List.of(
+        getElasticClientCache(),
+        getSettingCache()
+    ));
     return manager;
   }
 
@@ -38,6 +39,11 @@ public class CacheConfig {
             }
           }
         }).build());
+  }
+
+  private static CaffeineCache getSettingCache() {
+    return new CaffeineCache("settingCache",
+        Caffeine.newBuilder().expireAfterAccess(10, TimeUnit.MINUTES).build());
   }
 
 }

--- a/server/src/main/java/co/hyperflex/configs/CacheConfig.java
+++ b/server/src/main/java/co/hyperflex/configs/CacheConfig.java
@@ -1,9 +1,43 @@
 package co.hyperflex.configs;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @EnableCaching
 @Configuration
 public class CacheConfig {
+  private static final Logger log = LoggerFactory.getLogger(CacheConfig.class);
+
+  @Bean
+  public CacheManager cacheManager() {
+    CaffeineCache elasticClientCache = getElasticClientCache();
+
+    SimpleCacheManager manager = new SimpleCacheManager();
+    manager.setCaches(List.of(elasticClientCache));
+    return manager;
+  }
+
+  private static CaffeineCache getElasticClientCache() {
+    return new CaffeineCache("elasticClientCache",
+        Caffeine.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES).removalListener((Object key, Object value, RemovalCause cause) -> {
+          if (value instanceof AutoCloseable autoCloseable) {
+            try {
+              autoCloseable.close();
+            } catch (Exception e) {
+              log.warn("Error closing AutoCloseable", e);
+            }
+          }
+        }).build());
+  }
+
 }

--- a/server/src/main/java/co/hyperflex/prechecks/contexts/NodeContext.java
+++ b/server/src/main/java/co/hyperflex/prechecks/contexts/NodeContext.java
@@ -4,7 +4,9 @@ import co.hyperflex.clients.elastic.ElasticClient;
 import co.hyperflex.clients.kibana.KibanaClient;
 import co.hyperflex.entities.cluster.Cluster;
 import co.hyperflex.entities.cluster.ClusterNode;
+import co.hyperflex.entities.cluster.SelfManagedCluster;
 import co.hyperflex.entities.upgrade.ClusterUpgradeJob;
+import co.hyperflex.ssh.SshCommandExecutor;
 import org.slf4j.Logger;
 
 public class NodeContext extends PrecheckContext {
@@ -18,5 +20,17 @@ public class NodeContext extends PrecheckContext {
 
   public ClusterNode getNode() {
     return node;
+  }
+
+  public SshCommandExecutor getSshExecutor() {
+    if (getCluster() instanceof SelfManagedCluster selfManagedCluster) {
+      return new SshCommandExecutor(
+          node.getIp(),
+          22,
+          selfManagedCluster.getSshInfo().username(),
+          selfManagedCluster.getSshInfo().keyPath());
+    } else {
+      throw new IllegalStateException("SshCommandExecutor not supported yet for this type of cluster");
+    }
   }
 }

--- a/server/src/main/java/co/hyperflex/prechecks/contexts/resolver/PrecheckContextResolver.java
+++ b/server/src/main/java/co/hyperflex/prechecks/contexts/resolver/PrecheckContextResolver.java
@@ -54,7 +54,7 @@ public class PrecheckContextResolver {
         () -> new NotFoundException("Cluster not found: " + precheckRun.getClusterId()));
 
     ElasticClient elasticClient =
-        elasticsearchClientProvider.getElasticsearchClientByClusterId(clusterId);
+        elasticsearchClientProvider.getClientByClusterId(clusterId);
     KibanaClient kibanaClient =
         kibanaClientProvider.getKibanaClientByClusterId(clusterId);
 

--- a/server/src/main/java/co/hyperflex/prechecks/runner/PrecheckExecutorConfig.java
+++ b/server/src/main/java/co/hyperflex/prechecks/runner/PrecheckExecutorConfig.java
@@ -3,17 +3,18 @@ package co.hyperflex.prechecks.runner;
 import java.util.concurrent.Executor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
-@Async
+@EnableAsync
 public class PrecheckExecutorConfig {
+
   @Bean(name = "precheckAsyncExecutor")
   public Executor precheckAsyncExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(4);
-    executor.setMaxPoolSize(6);
+    executor.setCorePoolSize(6);
+    executor.setMaxPoolSize(8);
     executor.setThreadNamePrefix("Precheck-");
     executor.initialize();
     return executor;

--- a/server/src/main/java/co/hyperflex/prechecks/runner/PrecheckTaskExecutor.java
+++ b/server/src/main/java/co/hyperflex/prechecks/runner/PrecheckTaskExecutor.java
@@ -47,8 +47,6 @@ public class PrecheckTaskExecutor {
     try {
       MDC.put("precheckRunId", record.getId());
       precheckRunService.updatePrecheckStatus(record.getId(), PrecheckStatus.RUNNING);
-      notificationService.sendNotification(new PrecheckProgressChangeEvent());
-
       PrecheckContext context = precheckContextResolver.resolveContext(record);
       Precheck<?> precheck = precheckRegistry.getById(record.getPrecheckId())
           .orElseThrow(() -> new NotFoundException("Precheck not found: " + record.getPrecheckId()));

--- a/server/src/main/java/co/hyperflex/prechecks/runner/PrecheckTaskExecutor.java
+++ b/server/src/main/java/co/hyperflex/prechecks/runner/PrecheckTaskExecutor.java
@@ -50,20 +50,16 @@ public class PrecheckTaskExecutor {
       notificationService.sendNotification(new PrecheckProgressChangeEvent());
 
       PrecheckContext context = precheckContextResolver.resolveContext(record);
-      try {
-        Precheck<?> precheck = precheckRegistry.getById(record.getPrecheckId())
-            .orElseThrow(() -> new NotFoundException("Precheck not found: " + record.getPrecheckId()));
+      Precheck<?> precheck = precheckRegistry.getById(record.getPrecheckId())
+          .orElseThrow(() -> new NotFoundException("Precheck not found: " + record.getPrecheckId()));
 
-        switch (record.getType()) {
-          case NODE -> ((BaseNodePrecheck) precheck).run((NodeContext) context);
-          case INDEX -> ((BaseIndexPrecheck) precheck).run((IndexContext) context);
-          case CLUSTER -> ((BaseClusterPrecheck) precheck).run((ClusterContext) context);
-          default -> throw new IllegalArgumentException("Unknown precheck type: " + record.getType());
-        }
-        precheckRunService.updatePrecheckStatus(record.getId(), PrecheckStatus.COMPLETED);
-      } finally {
-        context.getElasticClient().getElasticsearchClient().close();
+      switch (record.getType()) {
+        case NODE -> ((BaseNodePrecheck) precheck).run((NodeContext) context);
+        case INDEX -> ((BaseIndexPrecheck) precheck).run((IndexContext) context);
+        case CLUSTER -> ((BaseClusterPrecheck) precheck).run((ClusterContext) context);
+        default -> throw new IllegalArgumentException("Unknown precheck type: " + record.getType());
       }
+      precheckRunService.updatePrecheckStatus(record.getId(), PrecheckStatus.COMPLETED);
 
     } catch (Exception e) {
       LOG.error("Error executing precheck: {}", record.getId(), e);

--- a/server/src/main/java/co/hyperflex/prechecks/scheduler/PrecheckSchedulerService.java
+++ b/server/src/main/java/co/hyperflex/prechecks/scheduler/PrecheckSchedulerService.java
@@ -98,7 +98,7 @@ public class PrecheckSchedulerService {
 
   public void scheduleIndexPrechecks(String upgradeJobId, String clusterId) {
     ElasticClient elasticClient =
-        elasticsearchClientProvider.getElasticsearchClientByClusterId(clusterId);
+        elasticsearchClientProvider.getClientByClusterId(clusterId);
     final List<String> indexes = elasticClient.getIndices();
     precheckRegistry.getIndexPrechecks()
         .stream()

--- a/server/src/main/java/co/hyperflex/services/ClusterUpgradeJobService.java
+++ b/server/src/main/java/co/hyperflex/services/ClusterUpgradeJobService.java
@@ -60,7 +60,7 @@ public class ClusterUpgradeJobService {
         .toList();
 
     ElasticClient elasticClient =
-        elasticsearchClientProvider.getElasticsearchClientByClusterId(clusterId);
+        elasticsearchClientProvider.getClientByClusterId(clusterId);
     InfoResponse info = elasticClient.getClusterInfo();
     String currentVersion = info.version().number();
 

--- a/server/src/main/java/co/hyperflex/services/ClusterUpgradeService.java
+++ b/server/src/main/java/co/hyperflex/services/ClusterUpgradeService.java
@@ -117,7 +117,7 @@ public class ClusterUpgradeService {
       log.error("Failed to retrieve active job for clusterId: {}", clusterId, e);
     }
     try {
-      ElasticClient client = elasticsearchClientProvider.getElasticsearchClientByClusterId(clusterId);
+      ElasticClient client = elasticsearchClientProvider.getClientByClusterId(clusterId);
       KibanaClient kibanaClient = kibanaClientProvider.getKibanaClientByClusterId(clusterId);
       GetClusterResponse cluster = clusterService.getClusterById(clusterId);
       PrecheckStatus precheckStatus = null;
@@ -174,7 +174,7 @@ public class ClusterUpgradeService {
         MDC.put("clusterId", cluster.getId());
         MDC.put("clusterUpgradeJobId", clusterUpgradeJob.getId());
 
-        ElasticClient elasticClient = elasticsearchClientProvider.getClient(cluster);
+        ElasticClient elasticClient = elasticsearchClientProvider.getClientByClusterId(cluster.getId());
         KibanaClient kibanaClient = kibanaClientProvider.getClient(cluster);
 
 

--- a/server/src/main/java/co/hyperflex/services/DeprecationService.java
+++ b/server/src/main/java/co/hyperflex/services/DeprecationService.java
@@ -64,7 +64,7 @@ public class DeprecationService {
 
   public List<GetDeprecationsResponse> getElasticDeprecations(String clusterId) {
     ElasticClient elasticClient =
-        elasticsearchClientProvider.getElasticsearchClientByClusterId(clusterId);
+        elasticsearchClientProvider.getClientByClusterId(clusterId);
 
     GetElasticDeprecationResponse deprecation = elasticClient.getDeprecation();
     List<GetDeprecationsResponse> responses = new LinkedList<>();

--- a/server/src/main/java/co/hyperflex/services/PrecheckReportService.java
+++ b/server/src/main/java/co/hyperflex/services/PrecheckReportService.java
@@ -167,7 +167,7 @@ public class PrecheckReportService {
 
 
   private String getESDeprecationsMdReport(String clusterId) {
-    ElasticClient client = elasticsearchClientProvider.getElasticsearchClientByClusterId(clusterId);
+    ElasticClient client = elasticsearchClientProvider.getClientByClusterId(clusterId);
     GetElasticDeprecationResponse deprecationResponse = client.getDeprecation();
 
     StringBuilder md = new StringBuilder("## Elasticsearch Deprecations\n\n");

--- a/server/src/main/java/co/hyperflex/ssh/CommandResult.java
+++ b/server/src/main/java/co/hyperflex/ssh/CommandResult.java
@@ -1,0 +1,10 @@
+package co.hyperflex.ssh;
+
+public record CommandResult(int exitCode, String stdout, String stderr) {
+  public boolean isSuccess() {
+    return exitCode == 0;
+
+  }
+}
+
+

--- a/server/src/main/java/co/hyperflex/ssh/SshCommandExecutor.java
+++ b/server/src/main/java/co/hyperflex/ssh/SshCommandExecutor.java
@@ -1,0 +1,64 @@
+package co.hyperflex.ssh;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.channel.ClientChannel;
+import org.apache.sshd.client.channel.ClientChannelEvent;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.util.security.SecurityUtils;
+
+public class SshCommandExecutor implements AutoCloseable {
+
+  private final SshClient client;
+  private final ClientSession session;
+  private final long timeoutSeconds;
+
+  public SshCommandExecutor(String host, int port, String username, String privateKeyPath, long timeoutSeconds) {
+
+    try {
+      this.timeoutSeconds = timeoutSeconds;
+      this.client = SshClient.setUpDefaultClient();
+      client.start();
+
+      session = client.connect(username, host, port)
+          .verify(timeoutSeconds, TimeUnit.SECONDS)
+          .getSession();
+
+      Iterable<KeyPair> keyPairs = SecurityUtils.loadKeyPairIdentities(session, null, new FileInputStream(privateKeyPath), null);
+      for (KeyPair kp : keyPairs) {
+        session.addPublicKeyIdentity(kp);
+      }
+
+      session.auth().verify(timeoutSeconds, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public CommandResult execute(String command) throws IOException {
+    try (ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+         ClientChannel channel = session.createExecChannel(command)) {
+
+      channel.setOut(stdout);
+      channel.setErr(stderr);
+
+      channel.open().verify(timeoutSeconds, TimeUnit.SECONDS);
+      channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED), TimeUnit.SECONDS.toMillis(timeoutSeconds));
+
+      int exitCode = channel.getExitStatus() != null ? channel.getExitStatus() : -1;
+      return new CommandResult(exitCode, stdout.toString(), stderr.toString());
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    session.close(false);
+    client.stop();
+  }
+}

--- a/server/src/main/java/co/hyperflex/ssh/SshCommandExecutor.java
+++ b/server/src/main/java/co/hyperflex/ssh/SshCommandExecutor.java
@@ -36,10 +36,10 @@ public class SshCommandExecutor implements AutoCloseable {
 
       session.auth().verify(timeoutSeconds, TimeUnit.SECONDS);
     } catch (Exception e) {
-      if (e.getCause() instanceof TimeoutException){
-        throw new RuntimeException("Error: Unable to establish SSH connection to host (IP: "+host+").");
+      if (e.getCause() instanceof TimeoutException) {
+        throw new RuntimeException("Unable to establish SSH connection to host (IP: " + host + ").");
       }
-      throw new RuntimeException("SSH authentication failed for host (IP: "+host+").");
+      throw new RuntimeException("SSH authentication failed for host (IP: " + host + ").");
     }
   }
 

--- a/server/src/main/java/co/hyperflex/utils/UpgradePathUtils.java
+++ b/server/src/main/java/co/hyperflex/utils/UpgradePathUtils.java
@@ -59,8 +59,8 @@ public class UpgradePathUtils {
       Map.entry("8.13", List.of("8.14.3", "8.15.5", "8.16.4", "8.17.2")),
       Map.entry("8.14", List.of("8.15.5", "8.16.4", "8.17.2")),
       Map.entry("8.15", List.of("8.16.4", "8.17.2")),
-      Map.entry("8.16", List.of("8.17.2")),
-      Map.entry("8.17", List.of("8.17.2"))
+      Map.entry("8.16", List.of("8.17.2", "8.17.3", "8.17.4", "8.17.5", "8.17.6", "8.17.7", "8.17.8", "8.17.9", "8.18.2", "8.19.0")),
+      Map.entry("8.17", List.of("8.17.2", "8.17.3", "8.17.4", "8.17.5", "8.17.6", "8.17.7", "8.17.8", "8.17.9", "8.18.2", "8.19.0"))
   );
 
   public static List<String> getPossibleUpgrades(String version) {

--- a/server/src/test/java/co/hyperflex/services/ClusterServiceTest.java
+++ b/server/src/test/java/co/hyperflex/services/ClusterServiceTest.java
@@ -74,7 +74,7 @@ class ClusterServiceTest {
     NodesInfoResponse nodesInfoResponse = mock(NodesInfoResponse.class);
 
     when(clusterMapper.toEntity(request)).thenReturn(cluster);
-    when(elasticsearchClientProvider.getClient(cluster)).thenReturn(elasticClient);
+    when(elasticsearchClientProvider.buildElasticClient(cluster)).thenReturn(elasticClient);
     when(kibanaClientProvider.getClient(cluster)).thenReturn(kibanaClient);
     when(elasticClient.getHealthStatus()).thenReturn("green");
     when(kibanaClient.getKibanaVersion()).thenReturn("8.1.0");
@@ -115,7 +115,7 @@ class ClusterServiceTest {
 
     when(clusterRepository.findById(clusterId)).thenReturn(Optional.of(cluster));
     when(sshKeyService.createSSHPrivateKeyFile(any(), any())).thenReturn("path/to/key");
-    when(elasticsearchClientProvider.getClient(cluster)).thenReturn(elasticClient);
+    when(elasticsearchClientProvider.buildElasticClient(cluster)).thenReturn(elasticClient);
     when(kibanaClientProvider.getClient(cluster)).thenReturn(kibanaClient);
     when(elasticClient.getHealthStatus()).thenReturn("green");
     when(kibanaClient.getKibanaVersion()).thenReturn("8.1.0");
@@ -173,7 +173,7 @@ class ClusterServiceTest {
     cluster.setElasticUrl(MOCK_ELASTIC_SEARCH_URL);
     cluster.setKibanaUrl(MOCK_KIBANA_URL);
     when(clusterMapper.toEntity(request)).thenReturn(cluster);
-    when(elasticsearchClientProvider.getClient(cluster)).thenThrow(new RuntimeException("Invalid credentials"));
+    when(elasticsearchClientProvider.buildElasticClient(cluster)).thenThrow(new RuntimeException("Invalid credentials"));
 
     // Act & Assert
     assertThrows(BadRequestException.class, () -> clusterService.add(request));

--- a/server/src/test/java/co/hyperflex/services/ClusterUpgradeServiceTest.java
+++ b/server/src/test/java/co/hyperflex/services/ClusterUpgradeServiceTest.java
@@ -80,7 +80,7 @@ class ClusterUpgradeServiceTest {
     deprecationCounts = new ClusterInfoResponse.DeprecationCounts(0, 0);
 
     // Common mocks for most tests
-    when(elasticsearchClientProvider.getElasticsearchClientByClusterId(CLUSTER_ID)).thenReturn(elasticClient);
+    when(elasticsearchClientProvider.getClientByClusterId(CLUSTER_ID)).thenReturn(elasticClient);
     when(kibanaClientProvider.getKibanaClientByClusterId(CLUSTER_ID)).thenReturn(kibanaClient);
     when(deprecationService.getKibanaDeprecationCounts(CLUSTER_ID)).thenReturn(deprecationCounts);
     when(deprecationService.getElasticDeprecationCounts(CLUSTER_ID)).thenReturn(deprecationCounts);

--- a/server/src/test/java/co/hyperflex/services/DeprecationServiceTest.java
+++ b/server/src/test/java/co/hyperflex/services/DeprecationServiceTest.java
@@ -60,7 +60,7 @@ class DeprecationServiceTest {
   @Test
   void getElasticDeprecations_returnsCorrectly() {
     // Arrange
-    when(elasticsearchClientProvider.getElasticsearchClientByClusterId(CLUSTER_ID)).thenReturn(elasticClient);
+    when(elasticsearchClientProvider.getClientByClusterId(CLUSTER_ID)).thenReturn(elasticClient);
     ElasticDeprecation deprecation = new ElasticDeprecation("Details", "critical", "Message", "URL");
     GetElasticDeprecationResponse elasticResponse = new GetElasticDeprecationResponse(
         List.of(deprecation), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList(),
@@ -100,7 +100,7 @@ class DeprecationServiceTest {
   @Test
   void getElasticDeprecationCounts_returnsCorrectCounts() {
     // Arrange
-    when(elasticsearchClientProvider.getElasticsearchClientByClusterId(CLUSTER_ID)).thenReturn(elasticClient);
+    when(elasticsearchClientProvider.getClientByClusterId(CLUSTER_ID)).thenReturn(elasticClient);
     ElasticDeprecation critical = new ElasticDeprecation(null, "critical", null, null);
     ElasticDeprecation warning = new ElasticDeprecation(null, "warning", null, null);
     GetElasticDeprecationResponse elasticResponse = new GetElasticDeprecationResponse(


### PR DESCRIPTION
# Changes
- Introduced caching for the Elasticsearch client to avoid rebuilding it on every request. The cache expires after 5 minutes of inactivity.
- Added an SshClient to execute shell commands directly, removing the dependency on Ansible for this functionality.