### PR TITLE
Improve start uptime and add k6 load test script

### DIFF
--- a/server/k6/index.js
+++ b/server/k6/index.js
@@ -1,0 +1,54 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+
+// ---------- Custom metrics ----------
+const qps = new Counter('qps');             // simple counter for total requests (useful for QPS calculations)
+const errors = new Rate('errors');          // fraction of failed checks
+const latency = new Trend('latency_ms');    // detailed latency trend in ms
+const respBytes = new Trend('response_bytes');
+
+// ---------- Config via environment vars ----------
+const TARGET = __ENV.TARGET_URL || 'https://localhost:8080/api/v1/clusters/68d14cc6e5220dedf785d69c/prechecks'; // target GET endpoint
+const RPS = __ENV.RPS ? parseInt(__ENV.RPS) : 200;
+const DURATION = __ENV.DURATION || '1m';
+
+// ---------- k6 options ----------
+export let options = {
+  insecureSkipTLSVerify: true,
+  scenarios: {
+    constant_rate: {
+      executor: 'constant-arrival-rate',
+      rate: RPS,
+      timeUnit: '1s',
+      duration: DURATION,
+      preAllocatedVUs: 60,
+      maxVUs: 500,
+    },
+  },
+
+  // thresholds let you fail the run if conditions are not met
+  thresholds: {
+    'http_req_duration': ['p(95)<500', 'p(99)<1500'],
+    'errors': ['rate<0.01']
+  },
+};
+
+// ---------- The VU function ----------
+export default function () {
+  const res = http.get(TARGET);
+  qps.add(1);
+  latency.add(res.timings.duration);         // timings.duration is total req time in ms
+  respBytes.add(res.body ? res.body.length : 0);
+
+  const ok = check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response not empty': (r) => r.body && r.body.length > 0,
+  });
+
+  if (!ok) {
+    errors.add(1);
+  } else {
+    errors.add(0);
+  }
+}

--- a/server/modules/precheck/src/main/java/co/hyperflex/precheck/contexts/resolver/PrecheckContextResolver.java
+++ b/server/modules/precheck/src/main/java/co/hyperflex/precheck/contexts/resolver/PrecheckContextResolver.java
@@ -15,6 +15,7 @@ import co.hyperflex.precheck.contexts.ClusterContext;
 import co.hyperflex.precheck.contexts.IndexContext;
 import co.hyperflex.precheck.contexts.NodeContext;
 import co.hyperflex.precheck.contexts.PrecheckContext;
+import co.hyperflex.precheck.core.Precheck;
 import co.hyperflex.precheck.entities.ClusterPrecheckRunEntity;
 import co.hyperflex.precheck.entities.IndexPrecheckRunEntity;
 import co.hyperflex.precheck.entities.NodePrecheckRunEntity;
@@ -25,7 +26,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class PrecheckContextResolver {
-  private static final Logger LOG = LoggerFactory.getLogger(PrecheckContextResolver.class);
   private final ClusterRepository clusterRepository;
   private final ElasticsearchClientProvider elasticsearchClientProvider;
   private final KibanaClientProvider kibanaClientProvider;
@@ -47,6 +47,7 @@ public class PrecheckContextResolver {
 
 
   public PrecheckContext resolveContext(PrecheckRunEntity precheckRun) {
+    Logger logger = LoggerFactory.getLogger(Precheck.class);
     String clusterId = precheckRun.getClusterId();
     ClusterUpgradeJobEntity clusterUpgradeJob =
         clusterUpgradeJobService.getActiveJobByClusterId(clusterId);
@@ -67,7 +68,7 @@ public class PrecheckContextResolver {
             kibanaClient,
             indexPrecheckRun.getIndex().getName(),
             clusterUpgradeJob,
-            LOG
+            logger
         );
       }
       case NodePrecheckRunEntity nodePrecheckRun -> {
@@ -80,7 +81,7 @@ public class PrecheckContextResolver {
             kibanaClient,
             clusterNode,
             clusterUpgradeJob,
-            LOG
+            logger
         );
       }
       case ClusterPrecheckRunEntity clusterPrecheckRun -> {
@@ -89,7 +90,7 @@ public class PrecheckContextResolver {
             elasticClient,
             kibanaClient,
             clusterUpgradeJob,
-            LOG
+            logger
         );
       }
       default -> throw new IllegalArgumentException("Unknown precheck type: " + precheckRun.getType());

--- a/server/modules/precheck/src/main/java/co/hyperflex/precheck/logger/PrecheckLoggingConfig.java
+++ b/server/modules/precheck/src/main/java/co/hyperflex/precheck/logger/PrecheckLoggingConfig.java
@@ -2,7 +2,7 @@ package co.hyperflex.precheck.logger;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import co.hyperflex.precheck.contexts.resolver.PrecheckContextResolver;
+import co.hyperflex.precheck.core.Precheck;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +22,7 @@ public class PrecheckLoggingConfig {
     precheckContextAwareAppender.setContext(context);
     precheckContextAwareAppender.start();
 
-    Logger rootLogger = context.getLogger(PrecheckContextResolver.class.getName());
+    Logger rootLogger = context.getLogger(Precheck.class);
     rootLogger.addAppender(precheckContextAwareAppender);
   }
 }

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -3,4 +3,7 @@ spring:
     mongodb:
       uri: mongodb://admin:admin123@seamless-upgrade-mongodb:27017/admin
       database: seamless-upgrade
-
+logging:
+  level:
+    root: WARN
+    co.hyperflex.precheck.core.Precheck: TRACE

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  main:
+    banner-mode: "off"
+  output:
+    ansi-enabled: "never"
   application:
     name: NextGen Seamless Upgrade
   data:
@@ -30,6 +34,10 @@ seamless:
 
 # enable/disable https
 server:
+  compression:
+    enabled: true
+    mime-types: text/html,text/xml,text/plain,application/json
+    min-response-size: 1024
   ssl:
     enabled: true
     key-store-type: PKCS12


### PR DESCRIPTION
```
 

         /\      Grafana   /‾‾/                                                                                                                                                                                                          
    /\  /  \     |\  __   /  /                                                                                                                                                                                                           
   /  \/    \    | |/ /  /   ‾‾\                                                                                                                                                                                                         
  /          \   |   (  |  (‾)  |                                                                                                                                                                                                        
 / __________ \  |_|\_\  \_____/ 

     execution: local
        script: index.js
        output: -

     scenarios: (100.00%) 1 scenario, 200 max VUs, 1m30s max duration (incl. graceful stop):
              * constant_rate: 100.00 iterations/s for 1m0s (maxVUs: 50-200, gracefulStop: 30s)



  █ THRESHOLDS 

    errors
    ✓ 'rate<0.01' rate=0.00%

    http_req_duration
    ✓ 'p(95)<500' p(95)=9.89ms
    ✓ 'p(99)<1500' p(99)=427.7ms


  █ TOTAL RESULTS 

    checks_total.......: 11894   198.203755/s
    checks_succeeded...: 100.00% 11894 out of 11894
    checks_failed......: 0.00%   0 out of 11894

    ✓ status is 200
    ✓ response not empty

    CUSTOM
    errors.........................: 0.00%  0 out of 5947
    latency_ms.....................: avg=15.149548 min=2.512  med=6.164  max=906.396  p(90)=8.6578 p(95)=9.8938 
    qps............................: 5947   99.101877/s
    response_bytes.................: avg=22463     min=22463  med=22463  max=22463    p(90)=22463  p(95)=22463  

    HTTP
    http_req_duration..............: avg=15.14ms   min=2.51ms med=6.16ms max=906.39ms p(90)=8.65ms p(95)=9.89ms 
      { expected_response:true }...: avg=15.14ms   min=2.51ms med=6.16ms max=906.39ms p(90)=8.65ms p(95)=9.89ms 
    http_req_failed................: 0.00%  0 out of 5947
    http_reqs......................: 5947   99.101877/s

    EXECUTION
    dropped_iterations.............: 54     0.899866/s
    iteration_duration.............: avg=26.85ms   min=2.56ms med=6.27ms max=1.88s    p(90)=8.88ms p(95)=10.13ms
    iterations.....................: 5947   99.101877/s
    vus............................: 1      min=1         max=75 
    vus_max........................: 104    min=75        max=104

    NETWORK
    data_received..................: 136 MB 2.3 MB/s
    data_sent......................: 927 kB 15 kB/s




running (1m00.0s), 000/104 VUs, 5947 complete and 0 interrupted iterations
constant_rate ✓ [======================================] 000/104 VUs  1m0s  100.00 iters/s
```