### PR TITLE
Update Cluster Health Check Logic to Handle Yellow and Green State

### DIFF
--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/services/ClusterUpgradeService.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/services/ClusterUpgradeService.java
@@ -242,7 +242,13 @@ public class ClusterUpgradeService {
 
                 if (!result.success()) {
                   log.error("Task [name: {}] failed for node [ip: {}] — {}", task.getName(), node.getIp(), result.message());
-                  throw new RuntimeException(result.message());
+
+                  if (task.isMandatoryTask(context)) {
+                    log.error("Task is mandatory. Failing upgrade.");
+                    throw new RuntimeException(result.message());
+                  } else {
+                    log.warn("Task is not mandatory. Continuing upgrade.");
+                  }
                 }
               }
 

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/Task.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/Task.java
@@ -14,4 +14,8 @@ public interface Task {
   default boolean skip(Map<String, Boolean> flags) {
     return false;
   }
+
+  default boolean isMandatoryTask(Context context) {
+    return true;
+  }
 }

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/elastic/WaitForGreenClusterStatusTask.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/elastic/WaitForGreenClusterStatusTask.java
@@ -2,6 +2,7 @@ package co.hyperflex.upgrade.tasks.elastic;
 
 import co.hyperflex.clients.elastic.ElasticClient;
 import co.hyperflex.clients.elastic.dto.cat.health.HealthRecord;
+import co.hyperflex.clients.elastic.dto.nodes.NodeInfo;
 import co.hyperflex.upgrade.tasks.Context;
 import co.hyperflex.upgrade.tasks.Task;
 import co.hyperflex.upgrade.tasks.TaskResult;
@@ -50,4 +51,20 @@ public class WaitForGreenClusterStatusTask implements Task {
   public boolean skip(Map<String, Boolean> flags) {
     return flags.getOrDefault("skipHealth", false);
   }
+
+  @Override
+  public boolean isMandatoryTask(Context context) {
+
+    List<NodeInfo> nodes = context.elasticClient()
+        .getNodesInfo()
+        .getNodes()
+        .values()
+        .stream()
+        .toList();
+
+    String targetVersion = context.config().targetVersion();
+
+    return nodes.stream().allMatch(node -> targetVersion.equals(node.getVersion()));
+  }
+
 }

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/elastic/WaitForGreenClusterStatusTask.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/elastic/WaitForGreenClusterStatusTask.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class WaitForGreenClusterStatusTask implements Task {
 
   private static final int MAX_RETRIES = 60;
-  private static final int RETRY_DELAY_MILLIS = 5000;
+  private static final int RETRY_DELAY_MILLIS = 3000;
 
   @Override
   public String getName() {


### PR DESCRIPTION
Update Cluster Health Check Logic to Handle Yellow and Green States for shard allocation failure