### PR TITLE
Fix kibana upgrade issue for 7.17 to 8.x upgrade.

### DIFF
--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/planner/kibana/KibanaUpgradePlanBuilder.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/planner/kibana/KibanaUpgradePlanBuilder.java
@@ -6,6 +6,7 @@ import co.hyperflex.core.upgrade.ClusterUpgradeJobEntity;
 import co.hyperflex.upgrade.planner.NodeUpgradePlanBuilder;
 import co.hyperflex.upgrade.planner.common.RepositoryPreparationStep;
 import co.hyperflex.upgrade.tasks.Task;
+import co.hyperflex.upgrade.tasks.kibana.BackupKibanaServiceFileTask;
 import co.hyperflex.upgrade.tasks.kibana.RestartKibanaServiceTask;
 import co.hyperflex.upgrade.tasks.kibana.UpdateKibanaPluginTask;
 import co.hyperflex.upgrade.tasks.kibana.UpdateKibanaTask;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class KibanaUpgradePlanBuilder implements NodeUpgradePlanBuilder {
 
   private final RepositoryPreparationStep repoStep;
+  private final BackupKibanaServiceFileTask kibanaServiceFileTask;
   private final UpdateKibanaTask update;
   private final RestartKibanaServiceTask restart;
   private final UpdateKibanaPluginTask updatePlugins;
@@ -27,12 +29,14 @@ public class KibanaUpgradePlanBuilder implements NodeUpgradePlanBuilder {
 
   public KibanaUpgradePlanBuilder(
       RepositoryPreparationStep repoStep,
+      BackupKibanaServiceFileTask kibanaServiceFileTask,
       UpdateKibanaTask update,
       RestartKibanaServiceTask restart,
       UpdateKibanaPluginTask updatePlugins,
       WaitForKibanaPortTask waitPort,
       WaitForKibanaReadyTask waitReady) {
     this.repoStep = repoStep;
+    this.kibanaServiceFileTask = kibanaServiceFileTask;
     this.update = update;
     this.restart = restart;
     this.updatePlugins = updatePlugins;
@@ -48,6 +52,7 @@ public class KibanaUpgradePlanBuilder implements NodeUpgradePlanBuilder {
   @Override
   public List<Task> buildPlan(ClusterNodeEntity node, ClusterUpgradeJobEntity job) {
     List<Task> tasks = new LinkedList<>(repoStep.prepare(node, job));
+    tasks.add(kibanaServiceFileTask);
     tasks.add(update);
     tasks.add(updatePlugins);
     tasks.add(restart);

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
@@ -32,7 +32,6 @@ public class BackupKibanaServiceFileTask extends AbstractAnsibleTask {
 
     AnsibleAdHocCommand command = AnsibleAdHocCommand.builder()
         .module("shell")
-
         .args(Map.of(
             "cmd", archiveScript,
             "executable", "/bin/bash"

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
@@ -24,14 +24,15 @@ public class BackupKibanaServiceFileTask extends AbstractAnsibleTask {
     logger.info("Imp: If present, it will be safely renamed to prevent systemd conflicts during the 8.x boot sequence.");
 
     String archiveScript =
-        "test -f /etc/systemd/system/kibana.service && "
-            + "mv /etc/systemd/system/kibana.service /etc/systemd/system/kibana.service.7x_backup && "
-            + "systemctl daemon-reload && "
+        "sudo test -f /etc/systemd/system/kibana.service && "
+            + "sudo mv /etc/systemd/system/kibana.service /etc/systemd/system/kibana.service.7x_backup && "
+            + "sudo systemctl daemon-reload && "
             + "echo 'Legacy file found and successfully archived.' || "
             + "echo 'No legacy file found. Skipping archive step.'";
 
     AnsibleAdHocCommand command = AnsibleAdHocCommand.builder()
         .module("shell")
+
         .args(Map.of(
             "cmd", archiveScript,
             "executable", "/bin/bash"

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
@@ -36,7 +36,7 @@ public class BackupKibanaServiceFileTask extends AbstractAnsibleTask {
     AnsibleAdHocCommand command = AnsibleAdHocCommand.builder()
         .module("shell")
         .args(Map.of(
-            "cmd", backupScript,
+            "cmd", "\"" + backupScript + "\"",
             "executable", "/bin/bash"
         ))
         .build();

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
@@ -1,0 +1,46 @@
+package co.hyperflex.upgrade.tasks.kibana;
+
+import co.hyperflex.ansible.commands.AnsibleAdHocCommand;
+import co.hyperflex.upgrade.tasks.AbstractAnsibleTask;
+import co.hyperflex.upgrade.tasks.Context;
+import co.hyperflex.upgrade.tasks.TaskResult;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BackupKibanaServiceFileTask extends AbstractAnsibleTask {
+
+  @Override
+  public String getName() {
+    return "Backup legacy 7.x Kibana systemd override";
+  }
+
+  @Override
+  public TaskResult run(Context context) {
+    final Logger logger = context.logger();
+
+    logger.info("Imp: Checking for legacy 7.x systemd service file at /etc/systemd/system/kibana.service...");
+    logger.info("Imp: If present, it will be safely renamed to prevent systemd conflicts during the 8.x boot sequence.");
+
+    String backupScript =
+        "if [ -f /etc/systemd/system/kibana.service ]; then " +
+            "echo 'Legacy override file found. Backing up to .7x_backup...'; " +
+            "mv /etc/systemd/system/kibana.service /etc/systemd/system/kibana.service.7x_backup; " +
+            "systemctl daemon-reload; " +
+            "echo 'Backup complete and systemd daemon reloaded.'; " +
+            "else " +
+            "echo 'No legacy override file found. Skipping backup.'; " +
+            "fi";
+
+    AnsibleAdHocCommand command = AnsibleAdHocCommand.builder()
+        .module("shell")
+        .args(Map.of(
+            "cmd", backupScript,
+            "executable", "/bin/bash"
+        ))
+        .build();
+
+    return runAdHocCommand(command, context);
+  }
+}

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
@@ -23,20 +23,17 @@ public class BackupKibanaServiceFileTask extends AbstractAnsibleTask {
     logger.info("Imp: Checking for legacy 7.x systemd service file at /etc/systemd/system/kibana.service...");
     logger.info("Imp: If present, it will be safely renamed to prevent systemd conflicts during the 8.x boot sequence.");
 
-    String backupScript =
-        "if [ -f /etc/systemd/system/kibana.service ]; then "
-            + "echo 'Legacy override file found. Backing up to .7x_backup...'; "
-            + "mv /etc/systemd/system/kibana.service /etc/systemd/system/kibana.service.7x_backup; "
-            + "systemctl daemon-reload; "
-            + "echo 'Backup complete and systemd daemon reloaded.'; "
-            + "else "
-            + "echo 'No legacy override file found. Skipping backup.'; "
-            + "fi";
+    String archiveScript =
+        "test -f /etc/systemd/system/kibana.service && "
+            + "mv /etc/systemd/system/kibana.service /etc/systemd/system/kibana.service.7x_backup && "
+            + "systemctl daemon-reload && "
+            + "echo 'Legacy file found and successfully archived.' || "
+            + "echo 'No legacy file found. Skipping archive step.'";
 
     AnsibleAdHocCommand command = AnsibleAdHocCommand.builder()
         .module("shell")
         .args(Map.of(
-            "cmd", "\"" + backupScript + "\"",
+            "cmd", archiveScript,
             "executable", "/bin/bash"
         ))
         .build();

--- a/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
+++ b/server/modules/upgrade/src/main/java/co/hyperflex/upgrade/tasks/kibana/BackupKibanaServiceFileTask.java
@@ -24,14 +24,14 @@ public class BackupKibanaServiceFileTask extends AbstractAnsibleTask {
     logger.info("Imp: If present, it will be safely renamed to prevent systemd conflicts during the 8.x boot sequence.");
 
     String backupScript =
-        "if [ -f /etc/systemd/system/kibana.service ]; then " +
-            "echo 'Legacy override file found. Backing up to .7x_backup...'; " +
-            "mv /etc/systemd/system/kibana.service /etc/systemd/system/kibana.service.7x_backup; " +
-            "systemctl daemon-reload; " +
-            "echo 'Backup complete and systemd daemon reloaded.'; " +
-            "else " +
-            "echo 'No legacy override file found. Skipping backup.'; " +
-            "fi";
+        "if [ -f /etc/systemd/system/kibana.service ]; then "
+            + "echo 'Legacy override file found. Backing up to .7x_backup...'; "
+            + "mv /etc/systemd/system/kibana.service /etc/systemd/system/kibana.service.7x_backup; "
+            + "systemctl daemon-reload; "
+            + "echo 'Backup complete and systemd daemon reloaded.'; "
+            + "else "
+            + "echo 'No legacy override file found. Skipping backup.'; "
+            + "fi";
 
     AnsibleAdHocCommand command = AnsibleAdHocCommand.builder()
         .module("shell")


### PR DESCRIPTION
The issue was caused by legacy configuration settings retained from the previous version. Specifically, the logging.dest setting, which was valid in Kibana 7.x, has been removed in Kibana 8.x.